### PR TITLE
Adding IPTC as authority for all IPTC-managed schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ To improve interoperability IPTC has defined a set of controlled vocabularies --
 branded as NewsCodes --for the use with NewsML-G2 by anybody and a corresponding
 Catalog file. This file also includes linked non-IPTC vocabularies.
 
-The current version is 33, published in July 2019.
+The current version is 34, published in September 2019.
 
 The file is available from the URL:
-http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_33.xml
+http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_34.xml
 
 ## IPTC's Controlled Vocabulary Catalog for SportsML-G2
 

--- a/catalog.IPTC-G2-Standards_34.xml
+++ b/catalog.IPTC-G2-Standards_34.xml
@@ -1,0 +1,626 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- File: http://www.iptc.org/std/catalog/catalog.IPTC-G2-Standards_#.xml (# represents the version number of this file)
+
+	This file provides a Catalog for G2-Standards as defined by the common News Architecture
+	This catalog contains all currently existing IPTC maintained controlled vocabularies - branded as NewsCodes - 
+	and a set of new sets of NewsCodes for the G2-Standards - see the explanations in the headers below.
+
+	How to apply:
+	When creating an XML instance of any kind of item for a G2-Standard do this:
+	- either: copy and paste the <catalog> element from this file to the appropriate position in the item
+	- or: add a <catalogRef> element to the item and apply the URL of this file (wherever it is stored)
+		to the "href" attribute of the catalogRef element like: 
+		<catalogRef href="http://mydomain.org/files/catalog.IPTC-G2-Standards_99.xml" />
+
+	This file is provided as is by the International Press Telecommunication Council, IPTC - www.iptc.org
+	History / change log:
+	v 1 2008-03-04: initial version, derived from the draft versions, reflects the G2 NewsCodes approved on 2008-01-29
+	v 2 2008-05-02: the section of "existing IPTC NewsCodes" was reviewed to sort out taxonomies which do not comply with G2-Standards for formal technical reasons
+	v 3 2008-06-23: minor changes
+	v 4 2008-09-02: section 5 added: schemes used only for NewsML1
+	v 5 2008-11-07: section 6 added: IPTC-external vocabularies added
+    v 6 2008-11-11: changes in section 6
+	v 7 2009-04-29: added alias "ncostat" and "wldreg" and "medtop"
+	v8 2009-05-20: added News Provider and News Product (section 1)
+	v9 2009-06-19: added DigitalSourceType (section 1)
+	v10 2009-07-06: added TimeUnit (section 3.1)
+	v11 2009-10-01: added DimensionUnit (section 3.1), added Dummy (1) TimeUnit alias modified
+	v12 2010-07-23: added Concept Relation (crel), comments modified
+	v13 2010-12-16: added cwarn, app,sig, plinat
+	v14 2011-01-21: adding riaspect, riscope, hopaction, hatarget, hashtype, hashscope
+	v15 2011-08-16: added skos, sov, colin, videodef, sev
+	v16 2011-11-04: added howextr
+	v17 2011-12-13: added nmsig and the ANPA1312 external CVs
+	v18 2011-12-23: error fixed: the MediaType CVs of G2 and NewsML 1 had the same scheme URI, 
+		for the CV of NewsML 1 with the alias "medtyp" the URI was changed to "http://cv.iptc.org/newscodes/mediatype1/"
+	v19 2012-09-12: external CV added: http://cvx.iptc.org/iso10383-mic
+	v20 2013-01-10: descriptions of schemes added. Generated from the IPTC concept management tool, schemes are sorted by their scheme URI
+	v21 2013-02-14: added rcalctype, rscaleunit, rtype, useracttype
+	v22 2013-05-17: added loutorient
+	v23 2013-11-25: added catinat, valfmt
+    v24 2014-01-20: modified: loctyp, added non-IPTC vocabs: cusip, sedol, tidm
+	v25 2014-11-03: added: ikos, dbpedia, freebase, wikidata, geonames, Musicbrainz/mb-*, 
+	v26 2015-01-12: added: gen(eric)
+	v27 2015-08-18: added: gics, secst
+	v28 2016-09-01: added: prodgenre
+	v29 2016-10-05: added: parasport
+	v30 2017-05-04: added: CVX/bcp47, VMHub Qualifier,(PMD mapping: altidrole, entityprop, rightsprop, aoprop, cptnoterole), sportfacet, sportfacetvalue)
+		2017-08-17: updated
+	v31 2018-01-25: added: cptdefrole, ctrole, ednoterole
+	v32 2018-04-04: added: cpprole
+	v33 2019-07-11: added: fisymtype
+    v34 2019-09-13: added IPTC authority to all IPTC-managed schemes
+-->
+<catalog xmlns="http://iptc.org/std/nar/2006-10-01/" additionalInfo="http://www.iptc.org/goto?G2cataloginfo">
+	<scheme alias="altidrole" uri="http://cv.iptc.org/newscodes/altidrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Role of an alternative identifier.</definition>
+		<name xml:lang="en-GB">Alternative Identifer Role</name>
+	</scheme>
+	<scheme alias="aoprop" uri="http://cv.iptc.org/newscodes/aoproperty/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Property of an artwork or object.</definition>
+		<name xml:lang="en-GB">Artwork or Object Property</name>
+	</scheme>
+	<scheme alias="app" uri="http://cv.iptc.org/newscodes/application/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how the metadata value was applied.</definition>
+		<name xml:lang="en-GB">Application of Metadata Values</name>
+	</scheme>
+	<scheme alias="aspfacet" uri="http://cv.iptc.org/newscodes/asportfacet/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">A sport facet of a concept.</definition>
+		<name xml:lang="en-GB">A Sport Facet</name>
+	</scheme>
+	<scheme alias="aspfacetvalue" uri="http://cv.iptc.org/newscodes/asportfacetvalue/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">A value which may be used with specific facet(s) of the Sport Facets NewsCodes - http://cv.iptc.org/newscodes/asportfacet/</definition>
+		<name xml:lang="en-GB">Value of a Sport Facet</name>
+	</scheme>
+	<scheme alias="acdc" uri="http://cv.iptc.org/newscodes/audiocodec/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a name of an audio-encoder/decoder. </definition>
+		<name xml:lang="en-GB">Audiocodec</name>
+		<note xml:lang="en-GB">Many of these encoders/decoders are controlled by international standards.</note>
+	</scheme>
+	<scheme alias="catinat" uri="http://cv.iptc.org/newscodes/catinature/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the nature of the content of a Catalog Item.
+</definition>
+		<name xml:lang="en-GB">Nature of a Catalog Item</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="chprop" uri="http://cv.iptc.org/newscodes/characteristicsproperty/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Defines the name and the semantics (not the value) of a physical characteristic of the content of a  NewsML 1 news item. </definition>
+		<name xml:lang="en-GB">Characteristics Property</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items. </note>
+	</scheme>
+	<scheme alias="cinat" uri="http://cv.iptc.org/newscodes/cinature/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the nature of the concept in a G2 Concept Item or Knowledge Item.</definition>
+		<name xml:lang="en-GB">Nature of a G2 Concept Item</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items. </note>
+	</scheme>
+	<scheme alias="colsp" uri="http://cv.iptc.org/newscodes/colorspace/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the colorspace of a digital image.</definition>
+		<name xml:lang="en-GB">Colorspace</name>
+	</scheme>
+	<scheme alias="colin" uri="http://cv.iptc.org/newscodes/colourindicator/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the basic colouring of an image.</definition>
+		<name xml:lang="en-GB">Colour Indicator</name>
+	</scheme>
+	<scheme alias="ctech" uri="http://cv.iptc.org/newscodes/commtech/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the communication technology used for this part of the contact info.</definition>
+		<name xml:lang="en-GB">Communication Technology</name>
+	</scheme>
+  <scheme alias="cptdefrole" uri="http://cv.iptc.org/newscodes/conceptdefinitionrole" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+    <definition xml:lang="en-GB">Role of a definition of a concept.</definition>
+    <name xml:lang="en-GB">Concept Definition Role</name>
+  </scheme>
+	<scheme alias="cptnoterole" uri="http://cv.iptc.org/newscodes/conceptnoterole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Role of a note about a concept.</definition>
+		<name xml:lang="en-GB">Concept Note Role</name>
+	</scheme>
+	<scheme alias="crel" uri="http://cv.iptc.org/newscodes/conceptrelation/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">The relationship between the current concept and the target concept.</definition>
+		<name xml:lang="en-GB">Concept Relation</name>
+	</scheme>
+	<scheme alias="conf" uri="http://cv.iptc.org/newscodes/confidence/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the degree of certainty that an applied metadata value is correct. </definition>
+		<name xml:lang="en-GB">Confidence</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items. </note>
+	</scheme>
+	<scheme alias="ciprol" uri="http://cv.iptc.org/newscodes/contactinfopartrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role of a part of a contact info component.</definition>
+		<name xml:lang="en-GB">Role of a Part of the Contact Info</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items. </note>
+	</scheme>
+	<scheme alias="cwarn" uri="http://cv.iptc.org/newscodes/contentwarning/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates why the content of the item should be reviewed as it may be perceived as being offensive.</definition>
+		<name xml:lang="en-GB">Content Warning</name>
+	</scheme>
+  <scheme alias="ctrol" uri="http://cv.iptc.org/newscodes/contributorrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+    <definition xml:lang="en-GB">Indicates the role of a contributor</definition>
+    <name xml:lang="en-GB">Contributor Role</name>
+  </scheme>
+	<scheme alias="cpnat" uri="http://cv.iptc.org/newscodes/cpnature/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the basic nature of a concept.</definition>
+		<name xml:lang="en-GB">Nature of a Concept</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="cpprole" uri="http://cv.iptc.org/newscodes/contentprodpartyrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">The role of a party (person or organisation) which created, originated, supplied, enhanced, distributed or contributed in another way to the content, or the role of a party which supported these activities.</definition>
+		<name xml:lang="en-GB">Content Production Party Role</name>
+	</scheme>
+	<scheme alias="drol" uri="http://cv.iptc.org/newscodes/descriptionrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role that a specific instance of a description takes among all descriptions.</definition>
+		<name xml:lang="en-GB">Description Role</name>
+	</scheme>
+	<scheme alias="digsrctype" uri="http://cv.iptc.org/newscodes/digitalsourcetype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates from which source a digital image was created. </definition>
+		<name xml:lang="en-GB">Digital Source Type</name>
+	</scheme>
+	<scheme alias="dimensionunit" uri="http://cv.iptc.org/newscodes/dimensionunit/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the unit used for measuring a dimension of content.</definition>
+		<name xml:lang="en-GB">Dimension Unit</name>
+	</scheme>
+  <scheme alias="ednoterole" uri="http://cv.iptc.org/newscodes/ednoterole" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+    <definition xml:lang="en-GB">Indicates the role of an editorial note</definition>
+    <name xml:lang="en-GB">Editorial Note Role</name>
+  </scheme>
+	<scheme alias="dummy" uri="http://cv.iptc.org/newscodes/dummy/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00"/>
+	<scheme alias="erol" uri="http://cv.iptc.org/newscodes/edrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role this item takes in an editorial workflow.</definition>
+		<name xml:lang="en-GB">Editorial Role</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="encd" uri="http://cv.iptc.org/newscodes/encoding/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates an encoding scheme used to transform data. </definition>
+		<name xml:lang="en-GB">Encoding</name>
+		<note xml:lang="en-GB">This vocabulary may be used with NewsML 1.x and NewsML-G2</note>
+	</scheme>
+	<scheme alias="entityprop" uri="http://cv.iptc.org/newscodes/entityproperty/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Property of an entity.</definition>
+		<name xml:lang="en-GB">Entity Property</name>
+	</scheme>
+	<scheme alias="ecirol" uri="http://cv.iptc.org/newscodes/eventcontactinforole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the class of the contact information.</definition>
+		<name xml:lang="en-GB">Event Contact Info Role</name>
+	</scheme>
+	<scheme alias="edconf" uri="http://cv.iptc.org/newscodes/eventdateconfirm/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates whether start and/or end dates and, optionally, times are confirmed.</definition>
+		<name xml:lang="en-GB">Event Date Confirmation</name>
+	</scheme>
+	<scheme alias="eocstat" uri="http://cv.iptc.org/newscodes/eventoccurstatus/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how certain the occurrence of the event is.</definition>
+		<name xml:lang="en-GB">Event Occurence Status</name>
+	</scheme>
+	<scheme alias="eorol" uri="http://cv.iptc.org/newscodes/eventorganiserrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role an organiser takes in the event.</definition>
+		<name xml:lang="en-GB">Event Organiser Role</name>
+	</scheme>
+	<scheme alias="eprol" uri="http://cv.iptc.org/newscodes/eventparticipantrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role a participant takes in the event.</definition>
+		<name xml:lang="en-GB">Event Participant Role</name>
+	</scheme>
+	<scheme alias="eregrol" uri="http://cv.iptc.org/newscodes/eventregrole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the class of a registration.</definition>
+		<name xml:lang="en-GB">Event Registration Role</name>
+	</scheme>
+	<scheme alias="fisymtype" uri="http://cv.iptc.org/newscodes/financialinstrumentsymboltype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the type of the symbol identifying a financial instrument.</definition>
+		<name xml:lang="en-GB">Financial Instrument Symbol Type</name>
+	</scheme>
+	<scheme alias="frmt" uri="http://cv.iptc.org/newscodes/format/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the technical format of content.</definition>
+		<name xml:lang="en-GB">Format</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items. </note>
+	</scheme>
+	<scheme alias="gen" uri="http://cv.iptc.org/newscodes/generic/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Generic concepts which could be applied to virtually all properties</definition>
+		<name xml:lang="en-GB">Generic Concepts</name>
+	</scheme>
+	<scheme alias="genre" uri="http://cv.iptc.org/newscodes/genre/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a nature, journalistic or intellectual characteristic of an item. </definition>
+		<name xml:lang="en-GB">Genre</name>
+	</scheme>
+	<scheme alias="hashscope" uri="http://cv.iptc.org/newscodes/hashscope/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the scope of a hash value.</definition>
+		<name xml:lang="en-GB">Hash Scope</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="hashtype" uri="http://cv.iptc.org/newscodes/hashtype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the function by which a hash value was generated.</definition>
+		<name xml:lang="en-GB">Hash Type</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="hopaction" uri="http://cv.iptc.org/newscodes/hopaction/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the action taken at a hop of the hop history.</definition>
+		<name xml:lang="en-GB">Hop Action</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="hatarget" uri="http://cv.iptc.org/newscodes/hopactiontarget/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the target to which an action taken at a hop of the hop history applies.</definition>
+		<name xml:lang="en-GB">Hop Action Target</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="howextr" uri="http://cv.iptc.org/newscodes/howextracted/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how a metadata value was extracted from the content.</definition>
+		<name xml:lang="en-GB">How Extracted</name>
+	</scheme>
+	<scheme alias="howpr" uri="http://cv.iptc.org/newscodes/howpresent/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how a metadata property relates to the content of a NewsML 1 news item. </definition>
+		<name xml:lang="en-GB">How Present</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="ikos" uri="http://cv.iptc.org/newscodes/ikos/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Terms required for organising IPTC's controlled vocabularies</definition>
+		<name xml:lang="en-GB">IPTC Knowledge Organisation System</name>
+	</scheme>
+	<scheme alias="impt" uri="http://cv.iptc.org/newscodes/importance/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the importance of an item of metadata applied to a news item. </definition>
+		<name xml:lang="en-GB">Importance</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items. </note>
+	</scheme>
+	<scheme alias="isrol" uri="http://cv.iptc.org/newscodes/infosourcerole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role of an information source.</definition>
+		<name xml:lang="en-GB">Information Source Role</name>
+	</scheme>
+	<scheme alias="irel" uri="http://cv.iptc.org/newscodes/itemrelation/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the relationship between the current item and the target resource.</definition>
+		<name xml:lang="en-GB">Item-Relation</name>
+	</scheme>
+	<scheme alias="irep" uri="http://cv.iptc.org/newscodes/itemrepresentation/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the way the target item is represented at this location.</definition>
+		<name xml:lang="en-GB">Item Representation</name>
+	</scheme>
+	<scheme alias="lbtyp" uri="http://cv.iptc.org/newscodes/labeltype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the type of a label. </definition>
+		<name xml:lang="en-GB">Label Type</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="lrol" uri="http://cv.iptc.org/newscodes/languagerole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role of the language among all languages used by the content.</definition>
+		<name xml:lang="en-GB">Language Role</name>
+	</scheme>
+	<scheme alias="loutorient" uri="http://cv.iptc.org/newscodes/layoutorientation/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates whether the human interpretation of the top of the image is aligned to its short or long side.</definition>
+		<name xml:lang="en-GB">Layout orientation</name>
+	</scheme>
+	<scheme alias="loctyp" uri="http://cv.iptc.org/newscodes/location/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the type of a location.</definition>
+		<name xml:lang="en-GB">Location Type</name>
+		<note xml:lang="en-GB">This vocabulary may be used with NewsML 1.x and NewsML-G2. </note>
+	</scheme>
+	<scheme alias="medtop" uri="http://cv.iptc.org/newscodes/mediatopic/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a subject of an item.</definition>
+		<name xml:lang="en-GB">Media Topic</name>
+		<note xml:lang="en-GB">The Media Topic NewsCodes is IPTC's new (as of December 2010) 1100-term taxonomy with a focus on text. The development started with the Subject Codes and extended the tree to 5 levels and reused the same 17 top level terms. The terms below the top level have been revised and rearranged. Each Media Topic provides a mapping back to one of the Subject Codes. </note>
+	</scheme>
+	<scheme alias="mtyp" uri="http://cv.iptc.org/newscodes/mediatype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a basic media type of news content.</definition>
+		<name xml:lang="en-GB">Media Type (G2)</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items. </note>
+	</scheme>
+	<scheme alias="medtype" uri="http://cv.iptc.org/newscodes/mediatype1/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a basic media type of news content.</definition>
+		<name xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items. </name>
+		<note xml:lang="en-GB">Media Type (NewsML 1)</note>
+	</scheme>
+	<scheme alias="nprt" uri="http://cv.iptc.org/newscodes/namepart/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the part of a name.</definition>
+		<name xml:lang="en-GB">Name Part</name>
+	</scheme>
+	<scheme alias="nrol" uri="http://cv.iptc.org/newscodes/namerole/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role this specific instance of a name takes among all names.</definition>
+		<name xml:lang="en-GB">Name Role</name>
+	</scheme>
+	<scheme alias="ncostat" uri="http://cv.iptc.org/newscodes/newscoveragestatus/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the intention of the news provider to cover an event. </definition>
+		<name xml:lang="en-GB">News Coverage Status</name>
+	</scheme>
+	<scheme alias="nityp" uri="http://cv.iptc.org/newscodes/newsitemtype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates, in a very broad way, the type of ContentItem carried by a NewsML 1 news item. </definition>
+		<name xml:lang="en-GB">News Item Type</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="nmsig" uri="http://cv.iptc.org/newscodes/newsmsgsignal/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how the items conveyed by a News Message should be processed. </definition>
+		<name xml:lang="en-GB">News Message Signal</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 News Messages.</note>
+	</scheme>
+	<scheme alias="nprod" uri="http://cv.iptc.org/newscodes/newsproduct/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a product of a News Provider.</definition>
+		<name xml:lang="en-GB">News Product</name>
+		<note xml:lang="en-GB">See also the News Provider NewsCodes </note>
+	</scheme>
+	<scheme alias="nprov" uri="http://cv.iptc.org/newscodes/newsprovider/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a News Provider registered with the IPTC.</definition>
+		<name xml:lang="en-GB">News Provider</name>
+		<note xml:lang="en-GB">See also the News Product NewsCodes </note>
+	</scheme>
+	<scheme alias="ninat" uri="http://cv.iptc.org/newscodes/ninature/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the nature of news in a News Item or Package Item.</definition>
+		<name xml:lang="en-GB">Nature of a News Item</name>
+		<note xml:lang="en-GB">Relates to the media type of the news content. / This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="not" uri="http://cv.iptc.org/newscodes/notation/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the notation of a ContentItem. </definition>
+		<name xml:lang="en-GB">Notation</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="oito" uri="http://cv.iptc.org/newscodes/ofinterestto/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a target audience for an item.</definition>
+		<name xml:lang="en-GB">Of Interest To</name>
+	</scheme>
+	<scheme alias="pgrmod" uri="http://cv.iptc.org/newscodes/pkggroupmode/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates whether the members of a Package Item group are complementary or alternative and whether their order is relevant.</definition>
+		<name xml:lang="en-GB">Packagegroup Mode</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="plinat" uri="http://cv.iptc.org/newscodes/plinature/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the nature of the content of a Planning Item.</definition>
+		<name xml:lang="en-GB">Nature of a Planning Item</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="prio" uri="http://cv.iptc.org/newscodes/priority/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the relative priority of an item for a distribution process. </definition>
+		<name xml:lang="en-GB">Priority</name>
+	</scheme>
+	<scheme alias="prodgenre" uri="http://cv.iptc.org/newscodes/productgenre/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Product genres for media objects</definition>
+		<name xml:lang="en-GB">Product Genre</name>
+	</scheme>
+	<scheme alias="prop" uri="http://cv.iptc.org/newscodes/property/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the type of a NewsML 1 Property element.</definition>
+		<name xml:lang="en-GB">Property Type</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="prov" uri="http://cv.iptc.org/newscodes/provider/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a company, publication or service provider.</definition>
+		<name xml:lang="en-GB">Provider (deprecated)</name>
+		<note xml:lang="en-GB">The successors of this vocabulary are the News Product and News Provider NewsCodes.</note>
+	</scheme>
+	<scheme alias="stat" uri="http://cv.iptc.org/newscodes/pubstatusg2/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the publishing status of a G2 item.</definition>
+		<name xml:lang="en-GB">Publishing Status (G2)</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items, NewsML 1 items use a different vocabulary. </note>
+	</scheme>
+	<scheme alias="rtype" uri="http://cv.iptc.org/newscodes/ratertype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the type of the parties which have contributed to a rating.</definition>
+		<name xml:lang="en-GB">Rater Type NewsCodes</name>
+	</scheme>
+	<scheme alias="rcalctype" uri="http://cv.iptc.org/newscodes/rcalctype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how the applied numeric rating value was calculated from a sample of values.</definition>
+		<name xml:lang="en-GB">Rating Calculation Type NewsCodes</name>
+	</scheme>
+	<scheme alias="rel" uri="http://cv.iptc.org/newscodes/relevance/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the relevance of a NewsML 1 news item to the target audience specified by "OfInterestTo".</definition>
+		<name xml:lang="en-GB">Relevance</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items. </note>
+	</scheme>
+	<scheme alias="rnd" uri="http://cv.iptc.org/newscodes/rendition/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a kind of content rendition.</definition>
+		<name xml:lang="en-GB">Content Rendition</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="riaspect" uri="http://cv.iptc.org/newscodes/riaspect/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the aspect of intellectual property rights that are expressed by a rights info property in a G2 item.</definition>
+		<name xml:lang="en-GB">Rights Info Aspect</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items. </note>
+	</scheme>
+	<scheme alias="rightsprop" uri="http://cv.iptc.org/newscodes/rightsproperty/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Property regarding rights.</definition>
+		<name xml:lang="en-GB">Rights Property</name>
+	</scheme>
+	<scheme alias="riscope" uri="http://cv.iptc.org/newscodes/riscope/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the scope of a rights info property in a G2 item.</definition>
+		<name xml:lang="en-GB">Rights Info Scope</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items. </note>
+	</scheme>
+	<scheme alias="role1" uri="http://cv.iptc.org/newscodes/role1/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the role of a NewsML 1 news item within a package of several news items.</definition>
+		<name xml:lang="en-GB">Role in Package</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="rscaleunit" uri="http://cv.iptc.org/newscodes/rscaleunit/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the units of a numeric rating value</definition>
+		<name xml:lang="en-GB">Rating Scale Unit NewsCodes</name>
+	</scheme>
+	<scheme alias="scn" uri="http://cv.iptc.org/newscodes/scene/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a type of scene covered by an item.</definition>
+		<name xml:lang="en-GB">Scene</name>
+	</scheme>
+	<scheme alias="sev" uri="http://cv.iptc.org/newscodes/severity/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how severe the impact from the signal is.</definition>
+		<name xml:lang="en-GB">Severity</name>
+		<note xml:lang="en-GB">This vocabulary applies only to G2 items.</note>
+	</scheme>
+	<scheme alias="sig" uri="http://cv.iptc.org/newscodes/signal/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">The signals are instructions to the processor of an item that the content may require special handling.</definition>
+		<name xml:lang="en-GB">Signal</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items.</note>
+	</scheme>
+	<scheme alias="pst1" uri="http://cv.iptc.org/newscodes/status1/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the current usability of a NewsML 1 news item.</definition>
+		<name xml:lang="en-GB">Status (NewsML 1)</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="subj" uri="http://cv.iptc.org/newscodes/subjectcode/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a subject of an item.</definition>
+		<name xml:lang="en-GB">Subject Code</name>
+		<note xml:lang="en-GB">The Subject Codes is IPTC 's original subject taxonomy, with a focus on text. It consists of about 1400 terms organized into 3 levels. </note>
+	</scheme>
+	<scheme alias="squ" uri="http://cv.iptc.org/newscodes/subjectqualifier/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a narrower attribute-like context for a Subject Code,  e.g. for sports: the gender of participants, indoor/outdoor competition etc.</definition>
+		<name xml:lang="en-GB">Subject Qualifier</name>
+		<note xml:lang="en-GB">This vocabulary should be used with the Subject Codes</note>
+	</scheme>
+	<scheme alias="timeunit" uri="http://cv.iptc.org/newscodes/timeunit/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the unit of time used for measuring the length of audio or video content. </definition>
+		<name xml:lang="en-GB">Time Unit</name>
+	</scheme>
+	<scheme alias="tpctyp" uri="http://cv.iptc.org/newscodes/topictype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the type of a concept represented by a topic.</definition>
+		<name xml:lang="en-GB">Topic Type</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML 1.x items.</note>
+	</scheme>
+	<scheme alias="urgy" uri="http://cv.iptc.org/newscodes/urgency/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the editorial urgency of an item.</definition>
+		<name xml:lang="en-GB">Urgency</name>
+	</scheme>
+	<scheme alias="useracttype" uri="http://cv.iptc.org/newscodes/useractiontype/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the type of user action.</definition>
+		<name xml:lang="en-GB">User Action Type NewsCodes</name>
+	</scheme>
+	<scheme alias="valfmt" uri="http://cv.iptc.org/newscodes/valueformat/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the format of a string value.</definition>
+		<name xml:lang="en-GB">Value Format</name>
+	</scheme>
+	<scheme alias="vcdc" uri="http://cv.iptc.org/newscodes/videocodec/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a name of a video-encoder/decoder. </definition>
+		<name xml:lang="en-GB">Videocodec</name>
+		<note xml:lang="en-GB">Many of these encoders/decoders are controlled by international standards. </note>
+	</scheme>
+	<scheme alias="videodef" uri="http://cv.iptc.org/newscodes/videodefinition/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates the video definition by basic terms.</definition>
+		<name xml:lang="en-GB">Video Definition</name>
+	</scheme>
+	<scheme alias="ivqu" uri="http://cv.iptc.org/newscodes/videoqualifier/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Qualifier of a video metadata property.</definition>
+		<name xml:lang="en-GB">Video Qualifier</name>
+	</scheme>
+	<scheme alias="sov" uri="http://cv.iptc.org/newscodes/videoscaling/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates how video content is scaled.</definition>
+		<name xml:lang="en-GB">Video Scaling</name>
+	</scheme>
+	<scheme alias="why" uri="http://cv.iptc.org/newscodes/whypresent/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates why the metadata value has been included.</definition>
+		<name xml:lang="en-GB">Why Present</name>
+		<note xml:lang="en-GB">This vocabulary applies only to NewsML-G2 items. </note>
+	</scheme>
+	<scheme alias="wldreg" uri="http://cv.iptc.org/newscodes/worldregion/" authority="https://iptc.org/" modified="2019-09-13T12:00:00+00:00">
+		<definition xml:lang="en-GB">Indicates a region of the world. </definition>
+		<name xml:lang="en-GB">World Region</name>
+	</scheme>
+<!--	IPTC external schemes -->
+	<scheme alias="a1312cat" uri="http://cvx.iptc.org/anpa1312-category/" modified="2011-12-15T12:00:00+00:00">
+		<definition xml:lang="en-GB">The category code of the story may be any of the single alpha characters from the vocabulary. (ANPA 1312 specs, section J)</definition>
+		<name xml:lang="en-GB">ANPA 1312 Category Codes</name>
+		<note xml:lang="en-GB">This vocabulary is owned by NAA - www.naa.org</note>
+	</scheme>
+	<scheme alias="a1312prio" uri="http://cvx.iptc.org/anpa1312-priority/" modified="2011-12-15T12:00:00+00:00">
+		<definition xml:lang="en-GB">The priority of a transmission is designated by any of the single alpha characters from the vocabulary.  (ANPA 1312 specs, section H)</definition>
+		<name xml:lang="en-GB">ANPA 1312 Priority Codes</name>
+		<note xml:lang="en-GB">The vocabulary is owned by NAA - www.naa.org</note>
+	</scheme>
+	<scheme alias="a1312svc" uri="http://cvx.iptc.org/anpa1312-servicelevel/" modified="2011-12-15T12:00:00+00:00">
+		<definition xml:lang="en-GB">The wire designator code will be an upper- or lowercase single alpha character that identifies the basic nature of the service. (ANPA 1312 specs, section B)</definition>
+		<name xml:lang="en-GB">ANPA 1312 Service Level Codes</name>
+		<note xml:lang="en-GB">The vocabulary is owned by NAA - www.naa.org</note>
+	</scheme>
+	<scheme alias="a1312vers" uri="http://cvx.iptc.org/anpa1312-version/" modified="2011-12-15T12:00:00+00:00">
+		<definition xml:lang="en-GB">The information in this field is designed to enable newspaper systems to distinguish new leads, inserts, corrections and adds, so that the process of automatically assembling separately transmitted portions of a story is not limited to putting the latest material at the bottom of the file. (ANPA 1312 specs, section O)</definition>
+		<name xml:lang="en-GB">ANPA 1312 Version Codes</name>
+		<note xml:lang="en-GB">The vocabulary is owned by NAA - www.naa.org</note>
+	</scheme>
+	<scheme alias="bcp47" uri="http://cvx.iptc.org/bcp47/" modified="2017-05-04T12:00:00+00:00">
+		<definition xml:lang="en-GB">Language tags are used to help identify languages, whether spoken, written, signed, or otherwise signaled, for the purpose of communication. </definition>
+		<name xml:lang="en-GB">BCP47 Language Tags</name>
+		<note xml:lang="en-GB">Body owning this CV: IETF - www.ietf.org</note>
+	</scheme>
+	<scheme alias="cusip" uri="http://cvx.iptc.org/cusip/" modified="2014-01-17T12:00:00+00:00">
+		<definition xml:lang="en-GB">The CUSIP is the National Securities Identification Number for products issued from both the United States and Canada.</definition>
+		<name xml:lang="en-GB">Committee on Uniform Security Identification Procedures</name>
+		<note xml:lang="en-GB">The codes are owned by the American Bankers Association, and operated by S&amp;P Capital IQ.</note>
+	</scheme>
+	<scheme alias="gics" uri="http://cvx.iptc.org/gics/" modified="2015-08-18T12:00:00+00:00">
+		<definition xml:lang="en-GB">The GICS classifications aim to enhance the investment research and asset management process for financial professionals worldwide. It is the result of numerous discussions with asset owners, portfolio managers and investment analysts around the world and is designed to respond to the global financial community's need for an accurate, complete and standard industry definition.</definition>
+		<name xml:lang="en-GB">GICS - Global Industry Categorisation Standard</name>
+		<note xml:lang="en-GB">Body owning this CV: GICS was developed by MSCI and Standard &amp; Poor’s, and is maintained by MSCI.</note>
+	</scheme>
+	<scheme alias="isin" uri="http://cvx.iptc.org/isin/" modified="2008-02-29T12:00:00+00:00">
+		<definition xml:lang="en-GB">Security numbers based on the ISO 6166 standard.</definition>
+		<name xml:lang="en-GB">ISIN (International Securities Identifying Number)</name>
+		<note xml:lang="en-GB">The ISO 6166 standard is owned by ISO - www.iso.ch</note>
+	</scheme>
+	<scheme alias="mic" uri="http://cvx.iptc.org/iso10383-mic/" modified="2013-01-10T12:00:00+00:00">
+		<definition xml:lang="en-GB">This International Standard specifies the structure for a three-letter alphabetic code and an equivalent three-digit numeric code for the representation of currencies and funds. For those currencies having minor units, it also shows the decimal relationship between such units and the currency itself.</definition>
+		<name xml:lang="en-GB">ISO Market Identifer Codes (MIC) -ISO 10383</name>
+		<note xml:lang="en-GB">This vocabulary is owned by ISO (www.iso.org)</note>
+	</scheme>
+	<scheme alias="iso3166-1a2" uri="http://cvx.iptc.org/iso3166-1a2/" modified="2008-02-29T12:00:00+00:00">
+		<definition xml:lang="en-GB">Codes for the representation of names of countries and their subdivisions -- Part 1: Country codes. The short country names from ISO 3166-1 and the alpha-2 codes are made available by ISO at no charge for internal use and non-commercial purposes.</definition>
+		<name xml:lang="en-GB">ISO 2-letter country name codes - ISO 3166-1 alpha-2</name>
+		<note xml:lang="en-GB">This vocabulary is owned by ISO - www.iso.ch</note>
+	</scheme>
+	<scheme alias="iso3166-1a3" uri="http://cvx.iptc.org/iso3166-1a3/" modified="2008-02-29T12:00:00+00:00">
+		<definition xml:lang="en-GB">Codes for the representation of names of countries and their subdivisions -- Part 1: Country codes. The short country names from ISO 3166-1 and the alpha-2 codes are made available by ISO at no charge for internal use and non-commercial purposes.</definition>
+		<name xml:lang="en-GB">ISO 3-letter country name codes - ISO 3166-1 alpha-3</name>
+		<note xml:lang="en-GB">This vocabulary is owned by ISO - www.iso.ch</note>
+	</scheme>
+	<scheme alias="iso4217a" uri="http://cvx.iptc.org/iso4217a/" modified="2008-02-29T12:00:00+00:00">
+		<definition xml:lang="en-GB">This International Standard specifies the structure for a three-letter alphabetic code and an equivalent three-digit numeric code for the representation of currencies and funds. For those currencies having minor units, it also shows the decimal relationship between such units and the currency itself.</definition>
+		<name xml:lang="en-GB">ISO currency codes - ISO 4217 - alpha codes</name>
+		<note xml:lang="en-GB">The vocabulary is owned by ISO - www.iso.ch</note>
+	</scheme>
+	<scheme alias="iso4217n" uri="http://cvx.iptc.org/iso4217n/" modified="2008-02-29T12:00:00+00:00">
+		<definition xml:lang="en-GB">This International Standard specifies the structure for a three-letter alphabetic code and an equivalent three-digit numeric code for the representation of currencies and funds. For those currencies having minor units, it also shows the decimal relationship between such units and the currency itself.</definition>
+		<name xml:lang="en-GB">ISO currency codes - ISO 4217 - numeric codes</name>
+		<note xml:lang="en-GB">This vocabulary is owned by ISO - www.iso.ch</note>
+	</scheme>
+	<scheme alias="secst" uri="http://cvx.iptc.org/secst/" modified="2015-08-18T12:00:00+00:00">
+		<definition xml:lang="en-GB">The SEC Submission Type defines the specific submission type, and implied form specification, associated with filing a document to the U.S. SEC EDGAR database.
+</definition>
+		<name xml:lang="en-GB">SEC Submission Type</name>
+		<note xml:lang="en-GB">Body owning this CV: U.S. Securities and Exchange Commission Submission / Body owning the format of the codes: U.S. Securities and Exchange Commission Submission.</note>
+	</scheme>
+	<scheme alias="sedol" uri="http://cvx.iptc.org/sedol/" modified="2014-01-17T12:00:00+00:00">
+		<definition xml:lang="en-GB">A SEDOL is the National Securities Identification Number for products issued from both the United Kingdom and Ireland.</definition>
+		<name xml:lang="en-GB">Stock Exchange Daily Official List</name>
+		<note xml:lang="en-GB">The codes are owned by the London Stock Exchange.</note>
+	</scheme>
+	<scheme alias="tidm" uri="http://cvx.iptc.org/tidm/" modified="2014-01-17T12:00:00+00:00">
+		<definition xml:lang="en-GB">A TIDM identifies a UK listed security, and was previously known as an EPIC = Exchange Price Information Computer (code). Reuters and Bloomberg combine a TIDM code with a suffix.</definition>
+		<name xml:lang="en-GB">Tradable Instrument Display Mnemonics</name>
+		<note xml:lang="en-GB">The codes are owned by the London Stock Exchange.</note>
+	</scheme>
+	<scheme alias="dbpedia" uri="http://dbpedia.org/resource/" modified="2014-10-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">Entities, categories or other resources from DBpedia. DBpedia is a crowd-sourced community effort to extract structured information from Wikipedia and make this information available on the Web. Find more at http://dbpedia.org</definition>
+		<name xml:lang="en-GB">DBpedia resource</name>
+	</scheme>
+	<scheme alias="mb-artist" uri="http://musicbrainz.org/artist/" modified="2014-11-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">A community-maintained music encyclopedia that collects music metadata and makes it available to the public. Find more details about this vocabulary at https://musicbrainz.org/doc/Artist</definition>
+		<name xml:lang="en-GB">Musicbrainz artist resource</name>
+	</scheme>
+	<scheme alias="mb-label" uri="http://musicbrainz.org/label/" modified="2014-11-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">A community-maintained music encyclopedia that collects music metadata and makes it available to the public. Find more details about this vocabulary at https://musicbrainz.org/doc/Label</definition>
+		<name xml:lang="en-GB">Musicbrainz label resource</name>
+	</scheme>
+	<scheme alias="mb-recording" uri="http://musicbrainz.org/recording/" modified="2014-11-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">A community-maintained music encyclopedia that collects music metadata and makes it available to the public. Find more details about this vocabulary at https://musicbrainz.org/doc/Recording</definition>
+		<name xml:lang="en-GB">Musicbrainz recording resource</name>
+	</scheme>
+	<scheme alias="mb-release" uri="http://musicbrainz.org/release/" modified="2014-11-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">A community-maintained music encyclopedia that collects music metadata and makes it available to the public. Find more details about this vocabulary at https://musicbrainz.org/doc/Release</definition>
+		<name xml:lang="en-GB">Musicbrainz release resource</name>
+	</scheme>
+	<scheme alias="mb-releasegroup" uri="http://musicbrainz.org/release-group/" modified="2014-11-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">A community-maintained music encyclopedia that collects music metadata and makes it available to the public. Find more details about this vocabulary at https://musicbrainz.org/doc/Release_Group
+</definition>
+		<name xml:lang="en-GB">Musicbrainz release-group resource</name>
+	</scheme>
+	<scheme alias="mb-work" uri="http://musicbrainz.org/work/" modified="2014-11-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">A community-maintained music encyclopedia that collects music metadata and makes it available to the public. Find more details about this vocabulary at https://musicbrainz.org/doc/Work</definition>
+		<name xml:lang="en-GB">Musicbrainz work resource</name>
+	</scheme>
+	<scheme alias="geonames" uri="http://sws.geonames.org/" modified="2014-11-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">A crowd-sourced geographical database which covers all countries and contains over eight million placenames that are available free of charge.
+</definition>
+		<name xml:lang="en-GB">Geonames resource</name>
+	</scheme>
+	<scheme alias="freebase" uri="http://www.freebase.com" modified="2014-10-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">Entities, categories or other resources from Freebase. Freebase is an open, Creative Commons Attribution (aka CC-BY) licensed collection of structured data.</definition>
+		<name xml:lang="en-GB">Freebase resource</name>
+	</scheme>
+	<scheme alias="skos" uri="http://www.w3.org/2004/02/skos/core#" modified="2013-02-21T12:00:00+00:00">
+		<name xml:lang="en-GB">W3C SKOS namespace</name>
+		<note xml:lang="en-GB">This vocabulary is owned by W3C - www.w3.org</note>
+	</scheme>
+	<scheme alias="wikidata" uri="http://www.wikidata.org/entity/" modified="2014-10-03T12:00:00+00:00">
+		<definition xml:lang="en-GB">Wikidata is a free  database acting as central storage for structured data about Wikipedia and other Wikimedia sister projects like Wikivoyage, Wikisource, and others.</definition>
+		<name xml:lang="en-GB">Wikidata/Wikipedia resource</name>
+	</scheme>
+</catalog>


### PR DESCRIPTION
Also updating version number (including in README) and modified dates on all schemes where we have added the authority attribute.